### PR TITLE
Update PHP CS Fixer version from 3.8.0 to 3.9.5

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="http://github.com/inextensodigital/actions"
 LABEL "homepage"="http://github.com/inextensodigital"
 LABEL "maintainer"="IED <contact@inextenso.digital>"
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.8.0/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
+RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.9.5/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
     && chmod a+x /usr/local/bin/php-cs-fixer
 
 ENTRYPOINT ["php-cs-fixer", "fix", "--dry-run", "--diff"]


### PR DESCRIPTION
In order to resolve https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6430 and keep our PHP CS Fixer version up to date 😇 

Latest releases of PHP CS FIxer are available here : https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases