### PR TITLE
Revert "chore: update cs-fixer to php8.2"

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-alpine
+FROM php:8.1-cli-alpine
 
 LABEL "com.github.actions.name"="Php cs fixer"
 LABEL "com.github.actions.description"="Lint php files against coding standards"


### PR DESCRIPTION
Reverts fulll/actions#172
```
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.2.0.
To ignore this requirement please set `PHP_CS_FIXER_IGNORE_ENV`.
If you use PHP version higher than supported, you may experience code modified in a wrong way.
Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer .
```

🙈 
