### PR TITLE
revert php version

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-alpine
+FROM php:8.1-cli-alpine
 
 LABEL "com.github.actions.name"="Php cs fixer"
 LABEL "com.github.actions.description"="Lint php files against coding standards"


### PR DESCRIPTION
PHP 8.2 is not yet supported by cs fixer :'(
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6764