### PR TITLE
fix fulll/chapter-architect#154: update deploy ID support

### DIFF
--- a/.github/workflows/prepare-prod-deployment-workflow.yml
+++ b/.github/workflows/prepare-prod-deployment-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           gh api --method POST \
             -H "Accept: application/vnd.github+json" \
-            /repos/$GITHUB_REPOSITORY/deployments/$DEPLOY_ID/statuses \
+            /repos/${GITHUB_REPOSITORY}/deployments/${DEPLOY_ID}/statuses \
             -F environment=${{inputs.stage}} \
             -F state='in_progress' \
             -F description='Deployment in progress.'

--- a/.github/workflows/update-deployment-workflow.yml
+++ b/.github/workflows/update-deployment-workflow.yml
@@ -25,7 +25,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
-          deploy_id=$([${{inputs.stage}} != 'prod'] && cat DEPLOY_ID || ${DEPLOY_ID})
+          if [ ${{inputs.stage}} != 'prod' ]
+          then
+            deploy_id=$(cat DEPLOY_ID)
+          else
+            deploy_id=${DEPLOY_ID}
+          fi
           gh api --method POST \
             repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
             -H "Accept: application/vnd.github+json" \
@@ -65,7 +70,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
-          deploy_id=$([${{inputs.stage}} != 'prod'] && cat DEPLOY_ID || ${DEPLOY_ID})
+          if [ ${{inputs.stage}} != 'prod' ]
+          then
+            deploy_id=$(cat DEPLOY_ID)
+          else
+            deploy_id=${DEPLOY_ID}
+          fi
           gh api --method POST \
             repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/update-deployment-workflow.yml
+++ b/.github/workflows/update-deployment-workflow.yml
@@ -32,7 +32,7 @@ jobs:
             deploy_id=${DEPLOY_ID}
           fi
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/${deploy_id}/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='success' \
@@ -77,7 +77,7 @@ jobs:
             deploy_id=${DEPLOY_ID}
           fi
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/${deploy_id}/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='failure' \

--- a/.github/workflows/update-deployment-workflow.yml
+++ b/.github/workflows/update-deployment-workflow.yml
@@ -14,18 +14,13 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
-      - name: retrieve DEPLOY_ID
-        uses: actions/download-artifact@master
-        with:
-          name: DEPLOY_ID
-          path: .
-
       - name: "update deployment status [SUCCESS]"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/$(cat DEPLOY_ID)/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/${DEPLOY_ID}/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='success' \
@@ -51,20 +46,14 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - name: retrieve DEPLOY_ID
-        if: failure()
-        uses: actions/download-artifact@master
-        with:
-          name: DEPLOY_ID
-          path: .
-
       - name: "update deployment status [FAILURE]"
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/$(cat DEPLOY_ID)/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/${DEPLOY_ID}/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='failure' \

--- a/.github/workflows/update-deployment-workflow.yml
+++ b/.github/workflows/update-deployment-workflow.yml
@@ -14,13 +14,20 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
+      - name: retrieve DEPLOY_ID
+        if: ${{ inputs.stage != 'prod' }}
+        uses: actions/download-artifact@master
+        with:
+          name: DEPLOY_ID
+          path: .
       - name: "update deployment status [SUCCESS]"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
+          deploy_id=$([${{inputs.stage}} != 'prod'] && cat DEPLOY_ID || ${DEPLOY_ID})
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/${DEPLOY_ID}/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='success' \
@@ -46,14 +53,21 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
+      - name: retrieve DEPLOY_ID
+        if: ${{ inputs.stage != 'prod' }}
+        uses: actions/download-artifact@master
+        with:
+          name: DEPLOY_ID
+          path: .
       - name: "update deployment status [FAILURE]"
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_ID: ${{ github.event.deployment.id }}
         run: |
+          deploy_id=$([${{inputs.stage}} != 'prod'] && cat DEPLOY_ID || ${DEPLOY_ID})
           gh api --method POST \
-            repos/${GITHUB_REPOSITORY}/deployments/${DEPLOY_ID}/statuses \
+            repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses \
             -H "Accept: application/vnd.github+json" \
             -F environment=${{ inputs.stage }} \
             -F state='failure' \


### PR DESCRIPTION
- Use the same syntaxe everywhere to generate API endpoint.
- Use Github event value for `DEPLOY_ID`.


<img width="1002" alt="Capture d’écran 2023-02-13 à 09 29 30" src="https://user-images.githubusercontent.com/1318362/218408038-d7324127-a53b-4120-803a-d19115706b84.png">

See: https://github.com/fulll/purchase.api/actions/runs/4161346532/jobs/7199248964

Linked to fulll/chapter-architect#154